### PR TITLE
Fix incorrect reference to `domain` in `Loader::loadTextdomain`

### DIFF
--- a/wp-palvelu-plugin.php
+++ b/wp-palvelu-plugin.php
@@ -55,10 +55,11 @@ Class Loader {
   public static function loadTextdomain() {
 
     // Load translations first from the languages directory
-    $locale = apply_filters( 'plugin_locale', get_locale(), $domain );
+    $locale = apply_filters( 'plugin_locale', get_locale(), self::$domain );
+
     load_textdomain(
-            $domain,
-            WP_LANG_DIR . '/my-plugin/' . self::$domain . '-' . $locale . '.mo'
+      self::$domain,
+      WP_LANG_DIR . '/my-plugin/' . self::$domain . '-' . $locale . '.mo'
     );
 
     // And then from this plugin folder


### PR DESCRIPTION
`Loader::loadTextdomain` threw PHP notices because the `Loader::domain`
property was referenced without the `self` reference inside the method.

This is fixed and the `domain` property is referenced properly now.

Fixes #18.